### PR TITLE
Changes to danbooru module because of changed values in the file url …

### DIFF
--- a/modules/danbooru.js
+++ b/modules/danbooru.js
@@ -57,7 +57,14 @@ function requestImage(message, rating, attempts){
     const entry = arr[0]
 
     if(entry.hasOwnProperty("file_url"))
-      message.channel.send("https://danbooru.donmai.us" + entry.file_url)
+    {
+      url = entry.file_url;
+
+      if(url.startsWith("https://") || url.startsWith("http://"))
+        message.channel.send(url)
+      else
+        message.channel.send("https://danbooru.donmai.us" + url)
+    }
     else if(attempts > 0)
       requestImage(message, rating, attempts - 1)
     else


### PR DESCRIPTION
Danbooru no longer always returns a relative path with their images. Instead the file url may contain a compelte url to another subdomain (including a prefacing https:// ...). In light of this the module was changed to return the url as is in case it detects a http:// or https:// in front of it.